### PR TITLE
Use Editor theme for UI elements

### DIFF
--- a/addons/gdmaim/ui/dock/dock.gd
+++ b/addons/gdmaim/ui/dock/dock.gd
@@ -19,6 +19,12 @@ func _ready() -> void:
 	for category in settings.get_categories():
 		var label : Label = preload("dock_category.tscn").instantiate()
 		label.text = category.visible_name
+		var label_background: Panel = label.get_node("Background")
+		theme_changed.connect(
+			func() -> void:
+				label_background.remove_theme_stylebox_override("panel")
+				label_background.add_theme_stylebox_override("panel", get_theme_stylebox("hover", "Button"))
+		)
 		$ScrollContainer/VBoxContainer.add_child(label)
 		for entry in category.entries:
 			if entry.visible_name:

--- a/addons/gdmaim/ui/dock/dock.tscn
+++ b/addons/gdmaim/ui/dock/dock.tscn
@@ -1,9 +1,6 @@
-[gd_scene load_steps=3 format=3 uid="uid://co43s08djflp5"]
+[gd_scene load_steps=2 format=3 uid="uid://co43s08djflp5"]
 
-[ext_resource type="Script" path="res://addons/gdmaim/ui/dock/dock.gd" id="1_se4hh"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_2vjsg"]
-bg_color = Color(0.129412, 0.14902, 0.180392, 1)
+[ext_resource type="Script" uid="uid://cljd6yfhsbpnt" path="res://addons/gdmaim/ui/dock/dock.gd" id="1_se4hh"]
 
 [node name="GDMaim" type="Panel"]
 anchors_preset = 15
@@ -11,7 +8,6 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_2vjsg")
 script = ExtResource("1_se4hh")
 
 [node name="ScrollContainer" type="ScrollContainer" parent="."]

--- a/addons/gdmaim/ui/dock/dock_category.tscn
+++ b/addons/gdmaim/ui/dock/dock_category.tscn
@@ -1,17 +1,15 @@
-[gd_scene load_steps=2 format=3 uid="uid://db3glsa3pdia3"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_dqyw0"]
-content_margin_left = 7.0
-content_margin_bottom = 1.0
-bg_color = Color(0.298039, 0.321569, 0.368627, 1)
-corner_radius_top_left = 3
-corner_radius_top_right = 3
-corner_radius_bottom_right = 3
-corner_radius_bottom_left = 3
+[gd_scene format=3 uid="uid://db3glsa3pdia3"]
 
 [node name="Category" type="Label"]
-theme_override_font_sizes/font_size = 15
-theme_override_styles/normal = SubResource("StyleBoxFlat_dqyw0")
 text = "Category"
 horizontal_alignment = 1
 vertical_alignment = 1
+
+[node name="Background" type="Panel" parent="."]
+show_behind_parent = true
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2

--- a/addons/gdmaim/ui/dock/dock_checkbox.tscn
+++ b/addons/gdmaim/ui/dock/dock_checkbox.tscn
@@ -1,17 +1,6 @@
-[gd_scene load_steps=3 format=3 uid="uid://nb5lkomvijrw"]
+[gd_scene load_steps=2 format=3 uid="uid://nb5lkomvijrw"]
 
-[ext_resource type="Script" path="res://addons/gdmaim/ui/dock/setting.gd" id="1_emcmu"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bv73c"]
-content_margin_left = 4.0
-content_margin_top = 2.0
-content_margin_right = 4.0
-content_margin_bottom = 2.0
-bg_color = Color(0.113725, 0.133333, 0.160784, 1)
-corner_radius_top_left = 4
-corner_radius_top_right = 4
-corner_radius_bottom_right = 4
-corner_radius_bottom_left = 4
+[ext_resource type="Script" uid="uid://j2b37qg48ayj" path="res://addons/gdmaim/ui/dock/setting.gd" id="1_emcmu"]
 
 [node name="CheckBox" type="CheckBox"]
 anchors_preset = 6
@@ -24,12 +13,6 @@ offset_top = -9.5
 offset_bottom = 9.5
 grow_horizontal = 0
 grow_vertical = 2
-theme_override_styles/focus = SubResource("StyleBoxFlat_bv73c")
-theme_override_styles/disabled = SubResource("StyleBoxFlat_bv73c")
-theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_bv73c")
-theme_override_styles/hover = SubResource("StyleBoxFlat_bv73c")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_bv73c")
-theme_override_styles/normal = SubResource("StyleBoxFlat_bv73c")
 text = "On"
 script = ExtResource("1_emcmu")
 node_var = "button_pressed"

--- a/addons/gdmaim/ui/dock/dock_lineedit.tscn
+++ b/addons/gdmaim/ui/dock/dock_lineedit.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://ctelo3fmr1bcm"]
 
-[ext_resource type="Script" path="res://addons/gdmaim/ui/dock/setting.gd" id="1_w54pe"]
+[ext_resource type="Script" uid="uid://j2b37qg48ayj" path="res://addons/gdmaim/ui/dock/setting.gd" id="1_w54pe"]
 
 [node name="LineEdit" type="LineEdit"]
 anchors_preset = 6

--- a/addons/gdmaim/ui/source_map_viewer/code_search.tscn
+++ b/addons/gdmaim/ui/source_map_viewer/code_search.tscn
@@ -1,9 +1,6 @@
-[gd_scene load_steps=8 format=3 uid="uid://crvfxjbaqfxn2"]
+[gd_scene load_steps=7 format=3 uid="uid://crvfxjbaqfxn2"]
 
-[ext_resource type="Script" path="res://addons/gdmaim/ui/source_map_viewer/code_search.gd" id="1_4mnsc"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_s0j7j"]
-bg_color = Color(0.0745098, 0.0862745, 0.101961, 1)
+[ext_resource type="Script" uid="uid://c10h567mcr352" path="res://addons/gdmaim/ui/source_map_viewer/code_search.gd" id="1_4mnsc"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_58b8g"]
 
@@ -17,7 +14,6 @@ bg_color = Color(0.0745098, 0.0862745, 0.101961, 1)
 
 [node name="CodeSearch" type="Panel"]
 custom_minimum_size = Vector2(0, 30)
-theme_override_styles/panel = SubResource("StyleBoxFlat_s0j7j")
 script = ExtResource("1_4mnsc")
 
 [node name="VBoxContainer" type="HBoxContainer" parent="."]

--- a/addons/gdmaim/ui/source_map_viewer/source_map_viewer.gd
+++ b/addons/gdmaim/ui/source_map_viewer/source_map_viewer.gd
@@ -13,6 +13,7 @@ var _export_mappings : Dictionary
 var _file_tree_items : Dictionary
 var _caret_lock : bool = false
 var _prev_preprocessor_hint : String
+var _prev_theme : Theme
 
 @onready var current_file : Label = $Panel/CurrentFile
 @onready var console : TextEdit = %Console
@@ -35,6 +36,7 @@ func _ready() -> void:
 	_load_script("")
 	
 	visibility_changed.connect(_on_visibility_changed)
+	theme_changed.connect(_setup_syntax_highlighter)
 	
 	var popup : PopupMenu = $Panel/HBoxContainer/MenuButton.get_popup()
 	popup.index_pressed.connect(_on_search_option_selected)
@@ -62,6 +64,7 @@ func _input(event : InputEvent) -> void:
 		else:
 			_on_close_requested()
 	elif event.keycode == KEY_F and event.ctrl_pressed:
+		get_viewport().set_input_as_handled()
 		if source_code.has_focus():
 			source_code_search.open()
 		elif exported_code.has_focus():
@@ -192,38 +195,42 @@ func _on_file_tree_item_activated() -> void:
 
 
 func _setup_syntax_highlighter() -> void:
-	if _prev_preprocessor_hint == _Settings.current.preprocessor_prefix:
+	EditorInterface.get_editor_theme()
+	if _prev_preprocessor_hint == _Settings.current.preprocessor_prefix and _prev_theme == EditorInterface.get_editor_theme():
 		return
 	
 	_prev_preprocessor_hint = _Settings.current.preprocessor_prefix
+	_prev_theme = EditorInterface.get_editor_theme()
+	
+	var editor_settings: EditorSettings = EditorInterface.get_editor_settings()
 	
 	var syntax_highlighter := CodeHighlighter.new()
-	syntax_highlighter.function_color = Color("#66e6ff")
-	syntax_highlighter.member_variable_color = Color("#bce0ff")
-	syntax_highlighter.number_color = Color("#a1ffe0")
-	syntax_highlighter.symbol_color = Color("#abc9ff")
+	syntax_highlighter.function_color = editor_settings.get_setting("text_editor/theme/highlighting/function_color")
+	syntax_highlighter.member_variable_color = editor_settings.get_setting("text_editor/theme/highlighting/member_variable_color")
+	syntax_highlighter.number_color = editor_settings.get_setting("text_editor/theme/highlighting/number_color")
+	syntax_highlighter.symbol_color = editor_settings.get_setting("text_editor/theme/highlighting/symbol_color")
 	
-	syntax_highlighter.add_color_region("'", "'", Color("#ffeda1"))
-	syntax_highlighter.add_color_region('"', '"', Color("#ffeda1"))
+	syntax_highlighter.add_color_region("'", "'", editor_settings.get_setting("text_editor/theme/highlighting/string_color"))
+	syntax_highlighter.add_color_region('"', '"', editor_settings.get_setting("text_editor/theme/highlighting/string_color"))
 	
-	syntax_highlighter.add_color_region("#", "", Color("#cdcfd280"))
-	syntax_highlighter.add_color_region(_prev_preprocessor_hint, "", Color("#7945c1")) #99b3cccc
+	syntax_highlighter.add_color_region("#", "", editor_settings.get_setting("text_editor/theme/highlighting/comment_color"))
+	syntax_highlighter.add_color_region(_prev_preprocessor_hint, "", editor_settings.get_setting("text_editor/theme/highlighting/doc_comment_color"))
 	
 	for keyword in ["var", "func", "signal", "enum", "const", "class", "class_name", "extends", "static", "self", "await", "super", "and", "or", "not", "is", "true", "false", "null", "load", "preload", "print", "prints"]:
-		syntax_highlighter.add_keyword_color(keyword, Color("#ff7085"))
+		syntax_highlighter.add_keyword_color(keyword, editor_settings.get_setting("text_editor/theme/highlighting/keyword_color"))
 	
 	for keyword in ["if", "else", "elif", "for", "in", "while", "return", "continue", "break", "pass", "match", "case"]:
-		syntax_highlighter.add_keyword_color(keyword, Color("#ff8ccc"))
+		syntax_highlighter.add_keyword_color(keyword, editor_settings.get_setting("text_editor/theme/highlighting/control_flow_keyword_color"))
 	
 	for keyword in [
 		"export", "export_category", "export_color_no_alpha", "export_custom", "export_dir", "export_enum", "export_exp_easing", "export_file", "export_flags", "export_global_dir", "export_global_file", "export_group",
 		"export_multiline", "export_node_path", "export_placeholder", "export_range", "export_storage", "export_subgroup", "icon", "onready", "rpc", "static_unload", "tool", "warning_ignore"]:
-		syntax_highlighter.add_keyword_color(keyword, Color("#ffb373"))
+		syntax_highlighter.add_keyword_color(keyword, editor_settings.get_setting("text_editor/theme/highlighting/gdscript/annotation_color"))
 	
 	for keyword in ["void", "bool", "int", "float", "String", "Array", "Dictionary", "Vector2", "Vector2i", "Vector3", "Vector3i", "Vector4", "Vector4i", "Transform2D", "Transform3D", "Quaternion", "Basis", "Callable",
 		"Variant", "PackedInt32Array", "PackedInt64Array", "PackedVector2Array", "PackedVector3Array", "PackedVector4Array", "PackedStringArray", "PackedByteArray", "PackedColorArray", "PackedFloat32Array",
 		"PackedFloat64Array", "AABB", "Color", "NodePath", "Plane", "Projection", "Rect2", "Rect2i", "RID", "Signal", "StringName", "Object"]:
-		syntax_highlighter.add_keyword_color(keyword, Color("#42ffc2"))
+		syntax_highlighter.add_keyword_color(keyword, editor_settings.get_setting("text_editor/theme/highlighting/base_type_color"))
 	
 	source_code.syntax_highlighter = syntax_highlighter
 	exported_code.syntax_highlighter = syntax_highlighter.duplicate()
@@ -265,6 +272,11 @@ func _unlock_caret() -> void:
 func _on_visibility_changed() -> void:
 	if visible:
 		_setup_syntax_highlighter()
+		exported_code.add_theme_color_override("font_readonly_color", exported_code.get_theme_color("font_color"))
+		source_code.add_theme_color_override("font_readonly_color", source_code.get_theme_color("font_color"))
+	else:
+		exported_code.remove_theme_color_override("font_readonly_color")
+		source_code.remove_theme_color_override("font_readonly_color")
 
 
 func _on_source_code_caret_changed() -> void:

--- a/addons/gdmaim/ui/source_map_viewer/source_map_viewer.tscn
+++ b/addons/gdmaim/ui/source_map_viewer/source_map_viewer.tscn
@@ -1,6 +1,6 @@
-[gd_scene load_steps=17 format=3 uid="uid://dqknu058384tm"]
+[gd_scene load_steps=8 format=3 uid="uid://dqknu058384tm"]
 
-[ext_resource type="Script" path="res://addons/gdmaim/ui/source_map_viewer/source_map_viewer.gd" id="1_xfxdk"]
+[ext_resource type="Script" uid="uid://chhs04qhau53n" path="res://addons/gdmaim/ui/source_map_viewer/source_map_viewer.gd" id="1_xfxdk"]
 [ext_resource type="PackedScene" uid="uid://crvfxjbaqfxn2" path="res://addons/gdmaim/ui/source_map_viewer/code_search.tscn" id="2_n0sd2"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_6bkrx"]
@@ -10,37 +10,14 @@ expand_margin_top = 26.0
 expand_margin_right = 1.0
 expand_margin_bottom = 1.0
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bdbcx"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_p8io0"]
 bg_color = Color(0.160784, 0.164706, 0.192157, 1)
 expand_margin_left = 1.0
 expand_margin_top = 26.0
 expand_margin_right = 1.0
 expand_margin_bottom = 1.0
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_s0j7j"]
-bg_color = Color(0.0745098, 0.0862745, 0.101961, 1)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ahkt6"]
-bg_color = Color(0.0705882, 0.141176, 0.180392, 1)
-
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_aq0q2"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_xmd2u"]
-bg_color = Color(0.901961, 0.894118, 0.941176, 0)
-
-[sub_resource type="SystemFont" id="SystemFont_g6j54"]
-font_names = PackedStringArray("Consolas")
-generate_mipmaps = true
-subpixel_positioning = 0
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_syit6"]
-content_margin_left = 5.0
-content_margin_top = 5.0
-content_margin_right = 5.0
-content_margin_bottom = 5.0
-bg_color = Color(0.0980392, 0.117647, 0.141176, 1)
-
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_bcbti"]
 
 [sub_resource type="CodeHighlighter" id="CodeHighlighter_8eucx"]
 number_color = Color(0.631373, 1, 0.878431, 1)
@@ -156,21 +133,6 @@ color_regions = {
 "' '": Color(1, 0.929412, 0.631373, 1)
 }
 
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_i2xq8"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_54gcf"]
-content_margin_left = 5.0
-content_margin_top = 5.0
-content_margin_right = 5.0
-content_margin_bottom = 5.0
-bg_color = Color(0, 0, 0, 0.258824)
-corner_radius_top_left = 2
-corner_radius_top_right = 2
-corner_radius_bottom_right = 2
-corner_radius_bottom_left = 2
-
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_e4wko"]
-
 [node name="SourceMapViewer" type="Window"]
 handle_input_locally = false
 title = "Source Map Viewer"
@@ -178,7 +140,7 @@ initial_position = 1
 size = Vector2i(1800, 900)
 content_scale_size = Vector2i(100, 100)
 theme_override_styles/embedded_border = SubResource("StyleBoxFlat_6bkrx")
-theme_override_styles/embedded_unfocused_border = SubResource("StyleBoxFlat_bdbcx")
+theme_override_styles/embedded_unfocused_border = SubResource("StyleBoxFlat_p8io0")
 script = ExtResource("1_xfxdk")
 
 [node name="BG" type="Panel" parent="."]
@@ -187,14 +149,12 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_s0j7j")
 
 [node name="Panel" type="Panel" parent="."]
 anchors_preset = 10
 anchor_right = 1.0
 offset_bottom = 25.0
 grow_horizontal = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_ahkt6")
 
 [node name="HBoxContainer" type="HBoxContainer" parent="Panel"]
 layout_mode = 1
@@ -211,8 +171,7 @@ grow_vertical = 2
 [node name="OpenFile" type="Button" parent="Panel/HBoxContainer"]
 layout_mode = 2
 theme_override_styles/focus = SubResource("StyleBoxEmpty_aq0q2")
-theme_override_styles/hover = SubResource("StyleBoxFlat_xmd2u")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_xmd2u")
+theme_override_styles/pressed = SubResource("StyleBoxEmpty_aq0q2")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_aq0q2")
 text = "Open"
 
@@ -333,13 +292,6 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_colors/current_line_color = Color(0.752941, 0, 0.0509804, 0.419608)
-theme_override_colors/font_readonly_color = Color(1, 1, 1, 1)
-theme_override_colors/font_color = Color(1, 1, 1, 1)
-theme_override_fonts/font = SubResource("SystemFont_g6j54")
-theme_override_font_sizes/font_size = 15
-theme_override_styles/normal = SubResource("StyleBoxFlat_syit6")
-theme_override_styles/focus = SubResource("StyleBoxEmpty_bcbti")
-theme_override_styles/read_only = SubResource("StyleBoxFlat_syit6")
 text = "extends Node
 
 
@@ -428,13 +380,6 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_colors/current_line_color = Color(0.752941, 0, 0.0509804, 0.419608)
-theme_override_colors/font_readonly_color = Color(1, 1, 1, 1)
-theme_override_colors/font_color = Color(1, 1, 1, 1)
-theme_override_fonts/font = SubResource("SystemFont_g6j54")
-theme_override_font_sizes/font_size = 15
-theme_override_styles/normal = SubResource("StyleBoxFlat_syit6")
-theme_override_styles/focus = SubResource("StyleBoxEmpty_bcbti")
-theme_override_styles/read_only = SubResource("StyleBoxFlat_syit6")
 editable = false
 drag_and_drop_selection_enabled = false
 minimap_draw = true
@@ -456,20 +401,13 @@ code_edit = NodePath("../Control/ExportedCode")
 
 [node name="BottomDock" type="TabContainer" parent="HSplitContainer/HSplitContainer/VSplitContainer"]
 layout_mode = 2
-theme_override_colors/font_unselected_color = Color(0.890196, 0.890196, 0.890196, 1)
-theme_override_colors/font_hovered_color = Color(1, 1, 1, 1)
-theme_override_colors/font_selected_color = Color(0.541176, 0.792157, 0.992157, 1)
 theme_override_constants/outline_size = 0
-theme_override_styles/tab_focus = SubResource("StyleBoxEmpty_i2xq8")
 current_tab = 0
 
 [node name="Console" type="TextEdit" parent="HSplitContainer/HSplitContainer/VSplitContainer/BottomDock"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 10)
 layout_mode = 2
-theme_override_styles/normal = SubResource("StyleBoxFlat_54gcf")
-theme_override_styles/focus = SubResource("StyleBoxEmpty_e4wko")
-theme_override_styles/read_only = SubResource("StyleBoxFlat_54gcf")
 text = "werqwe"
 editable = false
 drag_and_drop_selection_enabled = false


### PR DESCRIPTION
This makes the theme somewhat consistent with the rest of the editor, previously light theme was unusable because it changed the font colour in places but not the background colour.

I also fixed the problem where pressing Ctrl + F to search in the source map viewer would type F in the search as well.